### PR TITLE
fix(env): detect warp terminal for image picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "stu"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stu"
-version = "0.7.5"
+version = "0.7.6"
 description = "TUI application for AWS S3 written in Rust using ratatui"
 authors = ["Kyosuke Fujimoto <kyoro.f@gmail.com>"]
 homepage = "https://github.com/eran100/stu"

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,5 +1,13 @@
 use crate::config::Config;
 
+// Environment variable names and well-known values
+#[cfg(not(feature = "imggen"))]
+const TERM_PROGRAM_ENV: &str = "TERM_PROGRAM";
+#[cfg(not(feature = "imggen"))]
+const WARP_TERM_PROGRAM: &str = "WarpTerminal";
+#[cfg(not(feature = "imggen"))]
+const WARP_ENV: &str = "WARP";
+
 #[derive(Debug, Default, Clone)]
 pub struct Environment {
     pub image_picker: ImagePicker,
@@ -32,9 +40,9 @@ fn build_image_picker(image_preview_enabled: bool) -> ImagePicker {
                 let detected = picker.protocol_type();
 
                 // Detect Warp terminal via common env vars
-                let term_program = env::var("TERM_PROGRAM").unwrap_or_default();
-                let is_warp = term_program.eq_ignore_ascii_case("WarpTerminal")
-                    || env::var("WARP").is_ok();
+                let term_program = env::var(TERM_PROGRAM_ENV).unwrap_or_default();
+                let is_warp = term_program.eq_ignore_ascii_case(WARP_TERM_PROGRAM)
+                    || env::var(WARP_ENV).is_ok();
 
                 if is_warp {
                     // Prefer text-based rendering in Warp (no inline image support)
@@ -44,7 +52,9 @@ fn build_image_picker(image_preview_enabled: bool) -> ImagePicker {
                 let final_protocol = picker.protocol_type();
                 tracing::info!(
                     "image_picker: term_program={}, detected_protocol={:?}, final_protocol={:?}",
-                    term_program, detected, final_protocol
+                    term_program,
+                    detected,
+                    final_protocol
                 );
                 ImagePicker::Ok(picker)
             }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -24,18 +24,37 @@ pub enum ImagePicker {
 
 #[cfg(not(feature = "imggen"))]
 fn build_image_picker(image_preview_enabled: bool) -> ImagePicker {
+    use std::env;
+
     if image_preview_enabled {
         match ratatui_image::picker::Picker::from_query_stdio() {
-            Ok(picker) => {
-                if let ratatui_image::picker::ProtocolType::Halfblocks = picker.protocol_type() {
-                    ImagePicker::Error("This terminal does not support any protocol".into())
-                } else {
-                    ImagePicker::Ok(picker)
+            Ok(mut picker) => {
+                let detected = picker.protocol_type();
+
+                // Detect Warp terminal via common env vars
+                let term_program = env::var("TERM_PROGRAM").unwrap_or_default();
+                let is_warp = term_program.eq_ignore_ascii_case("WarpTerminal")
+                    || env::var("WARP").is_ok();
+
+                if is_warp {
+                    // Prefer text-based rendering in Warp (no inline image support)
+                    picker.set_protocol_type(ratatui_image::picker::ProtocolType::Halfblocks);
                 }
+
+                let final_protocol = picker.protocol_type();
+                tracing::info!(
+                    "image_picker: term_program={}, detected_protocol={:?}, final_protocol={:?}",
+                    term_program, detected, final_protocol
+                );
+                ImagePicker::Ok(picker)
             }
-            Err(e) => ImagePicker::Error(e.to_string()),
+            Err(e) => {
+                tracing::warn!("image_picker: failed to create picker: {}", e);
+                ImagePicker::Error(e.to_string())
+            }
         }
     } else {
+        tracing::info!("image_picker: disabled by config");
         ImagePicker::Disabled
     }
 }


### PR DESCRIPTION
Detect Warp terminals (TERM_PROGRAM or WARP env var) and prefer
text-based image rendering to avoid incompatible inline image
protocols. Log detected and final picker protocols and warn on picker
creation failure. Bump package version to 0.7.6.