### PR TITLE
feat(object): add content-encoding to file details

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -235,6 +235,7 @@ impl Client for AwsSdkClient {
         let last_modified = convert_datetime(output.last_modified().unwrap());
         let e_tag = output.e_tag().unwrap().trim_matches('"').to_string();
         let content_type = output.content_type().unwrap().to_string();
+        let content_encoding = output.content_encoding().map(|s| s.to_string());
         let storage_class = output
             .storage_class()
             .map_or("", |s| s.as_str())
@@ -249,6 +250,7 @@ impl Client for AwsSdkClient {
             last_modified,
             e_tag,
             content_type,
+            content_encoding,
             storage_class,
             key,
             s3_uri,

--- a/src/object.rs
+++ b/src/object.rs
@@ -63,6 +63,7 @@ pub struct FileDetail {
     pub last_modified: DateTime<Local>,
     pub e_tag: String,
     pub content_type: String,
+    pub content_encoding: Option<String>,
     pub storage_class: String,
     pub key: String,
     pub s3_uri: String,

--- a/src/pages/object_detail.rs
+++ b/src/pages/object_detail.rs
@@ -546,7 +546,7 @@ fn build_tabs(tab: &Tab, theme: &ColorTheme) -> Tabs<'static> {
 }
 
 fn build_detail_content_lines(detail: &FileDetail, ui_config: &UiConfig) -> Vec<Line<'static>> {
-    let mut details: Vec<Vec<Line<'static>>> = [
+    let mut details = [
         ("Name:", &detail.name),
         ("Size:", &format_size_byte(detail.size_byte)),
         (
@@ -569,7 +569,7 @@ fn build_detail_content_lines(detail: &FileDetail, ui_config: &UiConfig) -> Vec<
             Some(lines)
         }
     })
-    .collect();
+    .collect::<Vec<Vec<Line<'static>>>>();
 
     if let Some(encoding) = &detail.content_encoding {
         if !encoding.is_empty() {

--- a/src/pages/object_detail.rs
+++ b/src/pages/object_detail.rs
@@ -546,7 +546,7 @@ fn build_tabs(tab: &Tab, theme: &ColorTheme) -> Tabs<'static> {
 }
 
 fn build_detail_content_lines(detail: &FileDetail, ui_config: &UiConfig) -> Vec<Line<'static>> {
-    let details = [
+    let mut details: Vec<Vec<Line<'static>>> = [
         ("Name:", &detail.name),
         ("Size:", &format_size_byte(detail.size_byte)),
         (
@@ -570,6 +570,16 @@ fn build_detail_content_lines(detail: &FileDetail, ui_config: &UiConfig) -> Vec<
         }
     })
     .collect();
+
+    if let Some(encoding) = &detail.content_encoding {
+        if !encoding.is_empty() {
+            let lines = vec![
+                Line::from("Content-Encoding:".add_modifier(Modifier::BOLD)),
+                Line::from(format!(" {encoding}")),
+            ];
+            details.push(lines);
+        }
+    }
 
     flatten_with_empty_lines(details)
 }
@@ -1331,6 +1341,7 @@ mod tests {
             last_modified: parse_datetime("2024-01-02 13:01:02"),
             e_tag: "bef684de-a260-48a4-8178-8a535ecccadb".to_string(),
             content_type: "text/plain".to_string(),
+            content_encoding: None,
             storage_class: "STANDARD".to_string(),
             key: "file1".to_string(),
             s3_uri: "s3://bucket-1/file1".to_string(),

--- a/src/pages/object_preview.rs
+++ b/src/pages/object_preview.rs
@@ -580,6 +580,7 @@ mod tests {
             last_modified: parse_datetime("2024-01-02 13:01:02"),
             e_tag: "bef684de-a260-48a4-8178-8a535ecccadb".to_string(),
             content_type: "text/plain".to_string(),
+            content_encoding: None,
             storage_class: "STANDARD".to_string(),
             key: "file.txt".to_string(),
             s3_uri: "s3://bucket-1/file.txt".to_string(),

--- a/src/widget/copy_detail_dialog.rs
+++ b/src/widget/copy_detail_dialog.rs
@@ -421,6 +421,7 @@ mod tests {
             last_modified: parse_datetime("2024-01-02 13:01:02"),
             e_tag: "bef684de-a260-48a4-8178-8a535ecccadb".to_string(),
             content_type: "text/plain".to_string(),
+            content_encoding: None,
             storage_class: "STANDARD".to_string(),
             key: "file.txt".to_string(),
             s3_uri: "s3://bucket-1/file.txt".to_string(),


### PR DESCRIPTION
Add optional content_encoding to FileDetail and populate it in AwsSdkClient from S3 metadata.
Display Content-Encoding in the object detail view when present.
Update object previews and tests to include the new field.